### PR TITLE
adding support for sentinel password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 target/
 
 dump.rdb
+
+*.idea
+venv/

--- a/django_sentinel/sentinel.py
+++ b/django_sentinel/sentinel.py
@@ -83,9 +83,11 @@ class SentinelClient(DefaultClient):
 
         sentinel_timeout = self._options.get('SENTINEL_TIMEOUT', 1)
         password = self._options.get('PASSWORD', None)
+        sentinel_password = self._options.get('SENTINEL_PASSWORD', None)
         sentinel = SentinelClass(sentinel_hosts,
                                  socket_timeout=sentinel_timeout,
-                                 password=password)
+                                 password=password,
+                                 sentinel_kwargs={'password': sentinel_password})
 
         if write:
             host, port = sentinel.discover_master(master_name)


### PR DESCRIPTION
redis-sentinel allows for a sentinel-specific password set by the requirepass parameter in the redis-sentinel.conf file. If this password is configured, a redis.sentinel.MasterNotFoundError: No master found for 'mymaster' error will raise when attempting to perform cache operations. 
To resolve this, I've added a SENTINEL_PASSWORD parameter to be forwarded to the sentinel connection via sentinel_kwargs. 