### PR TITLE
adding sentinel kwargs parameter

### DIFF
--- a/django_sentinel/sentinel.py
+++ b/django_sentinel/sentinel.py
@@ -83,9 +83,11 @@ class SentinelClient(DefaultClient):
 
         sentinel_timeout = self._options.get('SENTINEL_TIMEOUT', 1)
         password = self._options.get('PASSWORD', None)
+        sentinel_kwargs = self._options.get('SENTINEL_KWARGS', None)
         sentinel = SentinelClass(sentinel_hosts,
                                  socket_timeout=sentinel_timeout,
-                                 password=password)
+                                 password=password,
+                                 sentinel_kwargs=sentinel_kwargs)
 
         if write:
             host, port = sentinel.discover_master(master_name)


### PR DESCRIPTION
redis-sentinel allows for a sentinel-specific password set by the requirepass parameter in the redis-sentinel.conf file. If this password is configured, a redis.sentinel.MasterNotFoundError: No master found for 'mymaster' error will raise when attempting to perform cache operations in django.
To resolve this, I've added a SENTINEL_KWARGS parameter that will forwarded to the sentinel connection via sentinel_kwargs. This can be used to set the sentinel password in the django settings. 
Example django cache settings:

CACHES = {
    'default': {
        'BACKEND': 'django_redis.cache.RedisCache',
        'LOCATION': 'redis_master/sentinel-host1:2639,sentinel-host2:2639/0',
        'OPTIONS': {
            'CLIENT_CLASS': 'django_sentinel.sentinel.SentinelClient',
            'PASSWORD': 'redis_pwd',
            'SENTINEL_KWARGS': {'password': 'sentinel_pwd'},
        },
    }
}